### PR TITLE
Enlarging dualcache on demand first time it's called.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PreallocationTools"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PreallocationTools"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "0.3.0"
+version = "0.2.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"


### PR DESCRIPTION
This addresses https://github.com/SciML/PreallocationTools.jl/issues/14

This adds a simple branch detecting whether the dualcache is too small (performance impact is very minor). If the cache is too small when it first gets called with get_tmp for a specific variable, it will be enlarged (which allocates, of course) and a warning gets thrown (telling the user what the proper chunk size would be). From the second call onwards, no allocations occur and the performance impact is very small due to branch prediction.

Hope that this keeps the spirit of the package!
