### PR TITLE
Fix issues with LazyBufferCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,8 @@ LazyBufferCache(f::F=identity)
 ```
 
 A `LazyBufferCache` is a `Dict`-like type for the caches which automatically defines
-new cache vectors on demand when they are required. The function `f` is a length
-map which maps `length_of_cache = f(length(u))`, which by default creates cache
-vectors of the same length.
+new cache arrays on demand when they are required. The function `f` maps
+`size_of_cache = f(size(u))`, which by default creates cache arrays of the same size.
 
 Note that `LazyBufferCache` does cause a dynamic dispatch, though it is type-stable.
 This gives it a ~100ns overhead, and thus on very small problems it can reduce

--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -87,13 +87,12 @@ struct LazyBufferCache{F<:Function}
 end
 
 # override the [] method
-function Base.getindex(b::LazyBufferCache, u::AbstractArray{T}) where {T}
+function Base.getindex(b::LazyBufferCache, u::T) where {T<:AbstractArray}
     n = b.lengthmap(size(u)) # required buffer length
-    buf = get!(b.bufs, T) do
-        similar(u, T, n) # buffer to allocate if it was not found in b.bufs
-    end::typeof(u) # declare type since b.bufs dictionary is untyped
-    # Doesn't work well with matrices, needs more thought!
-    #return resize!(buf, n) # resize the buffer if needed, e.g. if problem was resized
+    buf = get!(b.bufs, (T, n)) do
+        similar(u, n) # buffer to allocate if it was not found in b.bufs
+    end::T # declare type since b.bufs dictionary is untyped
+    return buf
 end
 
 export dualcache, get_tmp, LazyBufferCache

--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -83,7 +83,7 @@ allocated as needed and then cached within `b` for subsequent usage.
 struct LazyBufferCache{F<:Function}
     bufs::Dict # a dictionary mapping types to buffers
     lengthmap::F
-    LazyBufferCache(f::F=identity) where {F<:Function} = new{F}(Dict()) # start with empty dict
+    LazyBufferCache(f::F=identity) where {F<:Function} = new{F}(Dict(), f) # start with empty dict
 end
 
 # override the [] method

--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -75,22 +75,22 @@ end
 """
     b = LazyBufferCache(f=identity)
 
-A lazily allocated buffer object.  Given a vector `u`, `b[u]` returns a `Vector` of the
-same element type and length `f(length(u))` (defaulting to the same length), which is
-allocated as needed and then cached within `b` for subsequent usage.
+A lazily allocated buffer object.  Given an array `u`, `b[u]` returns an array of the
+same type and size `f(size(u))` (defaulting to the same size), which is allocated as
+needed and then cached within `b` for subsequent usage.
 
 """
 struct LazyBufferCache{F<:Function}
     bufs::Dict # a dictionary mapping types to buffers
-    lengthmap::F
+    sizemap::F
     LazyBufferCache(f::F=identity) where {F<:Function} = new{F}(Dict(), f) # start with empty dict
 end
 
 # override the [] method
 function Base.getindex(b::LazyBufferCache, u::T) where {T<:AbstractArray}
-    n = b.lengthmap(size(u)) # required buffer length
-    buf = get!(b.bufs, (T, n)) do
-        similar(u, n) # buffer to allocate if it was not found in b.bufs
+    s = b.sizemap(size(u)) # required buffer size
+    buf = get!(b.bufs, (T, s)) do
+        similar(u, s) # buffer to allocate if it was not found in b.bufs
     end::T # declare type since b.bufs dictionary is untyped
     return buf
 end


### PR DESCRIPTION
This PR fixes some bugs and aligns code and documentation for LazyBufferCache. In order of commits:

* `b = LazyBufferCache(f)` produces caches of arbitrary lengths when `f` is a closure.
  * MWE:
    ```julia
    using PreallocationTools

    LBC(n) = LazyBufferCache(_ -> n)

    b = LBC(5)
    b[ones(1)]  # Arbitrary length or OOM, should be length 5
    ```
  * Cause: `f` not being passed through to `new` in the constructor, making `b.lengthmap` an uninitialized instance of `typeof(f)`. (I'm surprised this is even allowed.)
  * Solution: Pass `f` through to `new`
* `b[x]` and `b[y]` return the same buffer as long as `x` and `y` have the same eltype, regardless of sizes and array types/storage
  * MWE:
    ```julia
    using CUDA
    using PreallocationTools

    b = LazyBufferCache()
    x = ones(4)
    b[x]  # Length 4 as expected
    b[x[1:3]]  # Still length 4, should be length 3
    b[CuArray(x[1:3])]  # Still trying to return a CPU array of length 4 => typeassert failure in getindex; should be CuArray of length 3
    ```
  * Cause: only `eltype(x)` used as key to `b.bufs`, not size and array type
  * Solution: use `(typeof(x), f(size(x)))` as key
  * Outstanding issue: the typeassert that ensures output type inferability relies on `typeof(similar(u, size)) === typeof(u)`. This does not hold for all `AbstractArray`s; ranges like `1:5` are the canonical counterexamples. This hardly seems relevant for LazyBufferCache use cases, so I've left it as is.
* Docs and behavior inconsistent: `f` is actually used as size map, not length map, so the LBC can both accept and return arrays of arbitrary dimension, not just vectors. In particular, matrices are already supported, contrary to what a comment in the code claims.
  * Solution: Update docs and variable names, e.g., from `b.lengthmap` to `b.sizemap`.

Some tests are probably in order, I'll get to that tomorrow.