### PR TITLE
Escape underscores in warning message

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -71,8 +71,8 @@ end
 
 function enlargedualcache!(dc, nelem) #warning comes only once per dualcache.
     chunksize = div(nelem, length(dc.du)) - 1
-    @warn "The supplied dualcache was too small and was enlarged. This incurrs allocations
-    on the first call to get_tmp. If few calls to get_tmp occur and optimal performance is essential,
+    @warn "The supplied dualcache was too small and was enlarged. This incurs allocations
+    on the first call to `get_tmp`. If few calls to `get_tmp` occur and optimal performance is essential,
     consider changing 'N'/chunk size of this dualcache to $chunksize."
     resize!(dc.dual_du, nelem)
 end


### PR DESCRIPTION
When using https://github.com/JuliaLogging/TerminalLoggers.jl, the warning message looks like

before
![image](https://user-images.githubusercontent.com/7318249/187839595-38058d6a-81d8-4b8e-9716-c724922e88bd.png)

after
![image](https://user-images.githubusercontent.com/7318249/187839714-89e7fffe-3923-4be7-828f-7cb88fd7a64c.png)
