### PR TITLE
Continue to support sizemaps that return Int in LazyBufferCache

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -209,6 +209,7 @@ struct LazyBufferCache{F <: Function}
     LazyBufferCache(f::F = identity) where {F <: Function} = new{F}(Dict(), f) # start with empty dict
 end
 
+similar_type(x::AbstractArray, s::Integer) = similar_type(x, (s,))
 function similar_type(x::AbstractArray{T}, s::NTuple{N, Integer}) where {T, N}
     # The compiler is smart enough to not allocate
     # here for simple types like Array and SubArray

--- a/test/general_lbc.jl
+++ b/test/general_lbc.jl
@@ -41,6 +41,12 @@ y = view(x, 1:900)
 @inferred cache[y]
 @test 0 == @allocated cache[y]
 
+cache_17 = LazyBufferCache(Returns(17))
+x = 1:10
+@inferred cache_17[x]
+@test 0 == @allocated cache_17[x]
+@test size(cache_17[x]) == (17,)
+
 cache = GeneralLazyBufferCache(T -> Vector{T}(undef, 1000))
 # GeneralLazyBufferCache is documented not to infer.
 # @inferred cache[Float64]


### PR DESCRIPTION
This avoids a 
```
no method matching similar_type(::..., ::Int64)
```
error

This used to be supported (for arrays whose similar is the same type) until #100, so it is not an expansion of public API, but a bugfix.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
