### PR TITLE
Add optional `initializer!` function to `LazyBufferCache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ A `LazyBufferCache` is a `Dict`-like type for the caches which automatically def
 new cache arrays on demand when they are required. The function `f` maps
 `size_of_cache = f(size(u))`, which by default creates cache arrays of the same size.
 
+By default the created buffers are not initialized, but a function `initializer!`
+can be supplied which is applied to the buffer when it is created, for instance `buf -> fill!(buf, 0.0)`.
+
 Note that `LazyBufferCache` is type-stable and contains no dynamic dispatch. This gives
 it a ~15ns overhead. The upside of `LazyBufferCache` is that the user does not have to
 worry about potential issues with chunk sizes and such: `LazyBufferCache` is much easier!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -208,6 +208,9 @@ A `LazyBufferCache` is a `Dict`-like type for the caches, which automatically de
 new cache arrays on demand when they are required. The function `f` maps
 `size_of_cache = f(size(u))`, which by default creates cache arrays of the same size.
 
+By default the created buffers are not initialized, but a function `initializer!`
+can be supplied which is applied to the buffer when it is created, for instance `buf -> fill!(buf, 0.0)`.
+
 Note that `LazyBufferCache` is type-stable and contains no dynamic dispatch. This gives
 it a ~15ns overhead. The upside of `LazyBufferCache` is that the user does not have to
 worry about potential issues with chunk sizes and such: `LazyBufferCache` is much easier!

--- a/test/lbc.jl
+++ b/test/lbc.jl
@@ -1,0 +1,6 @@
+using PreallocationTools: LazyBufferCache
+using Test
+
+b = LazyBufferCache(Returns(10); initializer! = buf -> fill!(buf, 0))
+
+@test b[Float64[]] == zeros(10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ if GROUP == "All" || GROUP == "Core"
     @safetestset "DiffCache Resizing" include("core_resizing.jl")
     @safetestset "DiffCache Nested Duals" include("core_nesteddual.jl")
     @safetestset "DiffCache Sparsity Support" include("sparsity_support.jl")
+    @safetestset "LazyBufferCache" include("lbc.jl")
     @safetestset "GeneralLazyBufferCache" include("general_lbc.jl")
 end
 


### PR DESCRIPTION
Fixes https://github.com/SciML/PreallocationTools.jl/issues/110

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
