### PR TITLE
Allow bigfloats through dualcaches

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -128,28 +128,40 @@ const dualcache = DiffCache
 
 Returns the `Dual` or normal cache array stored in `dc` based on the type of `u`.
 """
-function get_tmp(dc::DiffCache, u::T) where {T <: ForwardDiff.Dual}
-    nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
-    if nelem > length(dc.dual_du)
-        enlargediffcache!(dc, nelem)
+function get_tmp(dc::DiffCache, u::T) where {T <: ForwardDiff.Dual{T2}}
+    if isbitstype(T)
+        nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
+        if nelem > length(dc.dual_du)
+            enlargediffcache!(dc, nelem)
+        end
+        _restructure(dc.du, reinterpret(T, view(dc.dual_du, 1:nelem)))
+    else
+        _restructure(dc.du, zeros(T, size(dc.du)))
     end
-    _restructure(dc.du, reinterpret(T, view(dc.dual_du, 1:nelem)))
 end
 
 function get_tmp(dc::DiffCache, ::Type{T}) where {T <: ForwardDiff.Dual}
-    nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
-    if nelem > length(dc.dual_du)
-        enlargediffcache!(dc, nelem)
+    if isbitstype(T)
+        nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
+        if nelem > length(dc.dual_du)
+            enlargediffcache!(dc, nelem)
+        end
+        _restructure(dc.du, reinterpret(T, view(dc.dual_du, 1:nelem)))
+    else
+        _restructure(dc.du, zeros(T, size(dc.du)))
     end
-    _restructure(dc.du, reinterpret(T, view(dc.dual_du, 1:nelem)))
 end
 
 function get_tmp(dc::DiffCache, u::AbstractArray{T}) where {T <: ForwardDiff.Dual}
-    nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
-    if nelem > length(dc.dual_du)
-        enlargediffcache!(dc, nelem)
+    if isbitstype(T)
+        nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
+        if nelem > length(dc.dual_du)
+            enlargediffcache!(dc, nelem)
+        end
+        _restructure(dc.du, reinterpret(T, view(dc.dual_du, 1:nelem)))
+    else
+        _restructure(dc.du, zeros(T, size(dc.du)))
     end
-    _restructure(dc.du, reinterpret(T, view(dc.dual_du, 1:nelem)))
 end
 
 function get_tmp(dc::DiffCache, u::Union{Number, AbstractArray})

--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -128,7 +128,7 @@ const dualcache = DiffCache
 
 Returns the `Dual` or normal cache array stored in `dc` based on the type of `u`.
 """
-function get_tmp(dc::DiffCache, u::T) where {T <: ForwardDiff.Dual{T2}}
+function get_tmp(dc::DiffCache, u::T) where {T <: ForwardDiff.Dual}
     if isbitstype(T)
         nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
         if nelem > length(dc.dual_du)


### PR DESCRIPTION
We could in theory embed a LBC into the DualCache so that it reuses this vector, but I'm not sure it's worth it. Basically, if you have a T that's not bitstype then it's not going to reuse memory and it's going to have to re-allocate every number, so you have lots of memory operations already as requirements for making the T being acted on. In this case, you're really just looking for a functional fallback as there is no such thing as preallocation, so simply making the array you wish to see is a good option.
