### PR TITLE
FixedSizeDiffCache use `Nothing` instead of `nothing`

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -11,7 +11,7 @@ end
 function FixedSizeDiffCache(u::AbstractArray{T}, siz,
         ::Type{Val{chunk_size}}) where {T, chunk_size}
     x = ArrayInterface.restructure(u,
-        zeros(ForwardDiff.Dual{nothing, T, chunk_size},
+        zeros(ForwardDiff.Dual{Nothing, T, chunk_size},
             siz...))
     xany = Any[]
     FixedSizeDiffCache(deepcopy(u), x, xany)

--- a/test/core_dispatch.jl
+++ b/test/core_dispatch.jl
@@ -164,3 +164,12 @@ b = PreallocationTools.DiffCache(zeros(4), Val{4}())
 c = PreallocationTools.DiffCache(zeros(4), Val{4})
 @test structequal(a, b)
 @test structequal(a, b)
+
+
+# FixedSizeDiffCache get_tmp ReinterpretArray test
+# Ensures that get_tmp doesn't produce a Reinterpret array in some cases
+
+dual_cache = FixedSizeDiffCache([0.0, 0.0, 0.0], 3)
+dl = zeros(ForwardDiff.Dual{Nothing, Float64, 3}, 3)
+
+@test !(get_tmp(dual_cache, dl) isa Base.ReinterpretArray)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

In the construction of FixedSizeDiffCache we create the Dual numbers with tag `nothing`. This changes it to use `Nothing` for the tag, which is consistent with `zero` for Dual numbers.

```julia 
julia> zero(ForwardDiff.Dual)
Dual{Nothing}(0)
```

This is related to https://github.com/EnzymeAD/Enzyme.jl/issues/2371. 