### PR TITLE
Add resize! dispatch for DiffCache and FixedSizeDiffCache

### DIFF
--- a/test/core_resizing.jl
+++ b/test/core_resizing.jl
@@ -52,3 +52,45 @@ _du = DiffCache(du)
 f = A -> loss(_du, u, A, 0.0)
 analyticalsolution = [3.0 0; 0 0]
 @test ForwardDiff.gradient(f, A) ≈ analyticalsolution
+
+# Test resize! functionality for DiffCache
+@testset "resize! for DiffCache" begin
+    u = rand(10)
+    dc = DiffCache(u)
+
+    # Initial size
+    @test length(dc.du) == 10
+    @test length(dc.any_du) == 0  # Initially empty
+
+    # Resize to larger
+    resize!(dc, 20)
+    @test length(dc.du) == 20
+
+    # Resize to smaller
+    resize!(dc, 5)
+    @test length(dc.du) == 5
+
+    # Test that it returns the cache itself
+    @test resize!(dc, 8) === dc
+end
+
+# Test resize! functionality for FixedSizeDiffCache
+@testset "resize! for FixedSizeDiffCache" begin
+    u = rand(10)
+    dc = FixedSizeDiffCache(u)
+
+    # Initial size
+    @test length(dc.du) == 10
+    @test length(dc.any_du) == 0  # Initially empty
+
+    # Resize to larger
+    resize!(dc, 20)
+    @test length(dc.du) == 20
+
+    # Resize to smaller
+    resize!(dc, 5)
+    @test length(dc.du) == 5
+
+    # Test that it returns the cache itself
+    @test resize!(dc, 8) === dc
+end


### PR DESCRIPTION
## Summary
This PR adds `resize!` methods for `DiffCache` and `FixedSizeDiffCache` structs to fix resize! operations in downstream packages like Trixi.jl.

Fixes the error seen in https://github.com/trixi-framework/Trixi.jl/actions/runs/16993514504/job/48178504581?pr=2522#step:7:2026

## Changes
- Added `Base.resize!` methods for both `DiffCache` and `FixedSizeDiffCache`
- The methods resize the internal arrays (`du`, `dual_du`, `any_du`) appropriately
- Only resizes vector arrays (throws informative error for non-vectors since `resize!` doesn't work on matrices)
- Added ForwardDiff to weakdeps in Project.toml (was missing from weakdeps but was in extensions)

## Test plan
- [x] Added comprehensive tests for `resize!` functionality in `test/core_resizing.jl`
- [x] Tests verify resizing to both larger and smaller sizes
- [x] Tests confirm the method returns the cache object itself
- [x] Code formatted with JuliaFormatter using SciMLStyle

🤖 Generated with [Claude Code](https://claude.ai/code)