### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,7 @@ ADTypes = "1.16"
 Adapt = "4.3.0"
 Aqua = "0.8.11"
 ArrayInterface = "7.19.0"
+ExplicitImports = "1.14.0"
 ForwardDiff = "0.10.38, 1.0.1"
 LabelledArrays = "1.16.0"
 LinearAlgebra = "1.10"
@@ -44,6 +45,7 @@ julia = "1.10"
 [extras]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -61,4 +63,4 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ADTypes", "ForwardDiff", "Random", "LabelledArrays", "LinearAlgebra", "OrdinaryDiffEq", "Test", "RecursiveArrayTools", "Pkg", "SafeTestsets", "Optimization", "OptimizationOptimJL", "SparseArrays", "Symbolics", "SparseConnectivityTracer"]
+test = ["Aqua", "ADTypes", "ExplicitImports", "ForwardDiff", "Random", "LabelledArrays", "LinearAlgebra", "OrdinaryDiffEq", "Test", "RecursiveArrayTools", "Pkg", "SafeTestsets", "Optimization", "OptimizationOptimJL", "SparseArrays", "Symbolics", "SparseConnectivityTracer"]

--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -1,7 +1,8 @@
 module PreallocationTools
 
-using ArrayInterface, Adapt
-using PrecompileTools
+using Adapt: Adapt, adapt
+using ArrayInterface: ArrayInterface
+using PrecompileTools: @compile_workload, @setup_workload
 
 struct FixedSizeDiffCache{T <: AbstractArray, S <: AbstractArray}
     du::T

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using PreallocationTools
+using Test
+
+@testset "Explicit Imports" begin
+    @test check_no_implicit_imports(PreallocationTools) === nothing
+    @test check_no_stale_explicit_imports(PreallocationTools) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ end
 
 if GROUP == "All" || GROUP == "Core"
     @safetestset "Quality Assurance" include("qa.jl")
+    @safetestset "Explicit Imports" include("explicit_imports.jl")
     @safetestset "DiffCache Dispatch" include("core_dispatch.jl")
     @safetestset "DiffCache ODE tests" include("core_odes.jl")
     @safetestset "DiffCache Resizing" include("core_resizing.jl")


### PR DESCRIPTION
## Summary

- Convert implicit imports to explicit imports in `src/PreallocationTools.jl`:
  - `using Adapt: Adapt, adapt`  
  - `using ArrayInterface: ArrayInterface`
  - `using PrecompileTools: @compile_workload, @setup_workload`
- Add ExplicitImports.jl test to CI to ensure import hygiene is maintained
- Add ExplicitImports to test dependencies in Project.toml

## Test plan

- [x] Ran `check_no_implicit_imports(PreallocationTools)` - passes
- [x] Ran `check_no_stale_explicit_imports(PreallocationTools)` - passes
- [x] Full test suite passes locally

## Analysis

Before this PR, the package had 6 implicit imports:
- `Adapt` from Adapt
- `adapt` from Adapt
- `ArrayInterface` from ArrayInterface
- `PrecompileTools` from PrecompileTools
- `@compile_workload` from PrecompileTools
- `@setup_workload` from PrecompileTools

All are now explicit imports, and a CI test ensures this hygiene is maintained.

Note: The package accesses 2 non-public names from ArrayInterface (`parameterless_type` and `restructure`), but these are already accessed via qualified names (`ArrayInterface.parameterless_type`), which is the correct approach.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)