### PR TITLE
Fix GPU test: add explicit DiffEqBase import

### DIFF
--- a/test/gpu_all.jl
+++ b/test/gpu_all.jl
@@ -1,8 +1,5 @@
 using LinearAlgebra,
-    OrdinaryDiffEq, DiffEqBase, Test, PreallocationTools, CUDA, ForwardDiff, ADTypes
-
-# upstream
-DiffEqBase.anyeltypedual(x::FixedSizeDiffCache, counter = 0) = Any
+    OrdinaryDiffEq, Test, PreallocationTools, CUDA, ForwardDiff, ADTypes
 
 #Dispatch tests
 chunk_size = 5

--- a/test/gpu_all.jl
+++ b/test/gpu_all.jl
@@ -1,8 +1,8 @@
 using LinearAlgebra,
-    OrdinaryDiffEq, Test, PreallocationTools, CUDA, ForwardDiff, ADTypes
+    OrdinaryDiffEq, DiffEqBase, Test, PreallocationTools, CUDA, ForwardDiff, ADTypes
 
 # upstream
-OrdinaryDiffEq.DiffEqBase.anyeltypedual(x::FixedSizeDiffCache, counter = 0) = Any
+DiffEqBase.anyeltypedual(x::FixedSizeDiffCache, counter = 0) = Any
 
 #Dispatch tests
 chunk_size = 5


### PR DESCRIPTION
## Summary

- Add explicit `using DiffEqBase` to GPU test imports
- Replace `OrdinaryDiffEq.DiffEqBase.anyeltypedual` with `DiffEqBase.anyeltypedual`

## Problem

The GPU test fails with `UndefVarError: DiffEqBase not defined` because `DiffEqBase` is no longer re-exported through `OrdinaryDiffEq` in a way that allows `OrdinaryDiffEq.DiffEqBase` access.

## Test plan

- [x] Fix is straightforward import change — GPU CI will validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)