### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
+      - "/test/GPU"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,26 +11,16 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  downgrade:
+    name: "Downgrade"
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the remaining inline CI jobs to the centralized `SciML/.github` reusable workflows (all pinned `@v1`, `secrets: "inherit"` on every caller). Existing `name:`/`on:`/`concurrency:` blocks preserved.

## Converted (inline -> central)
- **FormatCheck.yml**: inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1` (preserves `group: Core`, `julia-version: "1.10"`, `skip: Pkg,TOML`; the old `ALLOW_RERESOLVE: false`/`alldeps` map to the central default behavior)

## Already central (left as-is)
- **Tests.yml** (`tests.yml@v1`, version x os matrix, `secrets: inherit`)
- **Documentation.yml** (`documentation.yml@v1`, `secrets: inherit`)

## Unchanged
- **GPU.yml** (self-hosted GPU runner job — no central equivalent in scope)
- **TagBot.yml**

## Other
- **dependabot.yml**: removed the `crate-ci/typos` version ignore (no longer pinned here); pointed the `julia` ecosystem at dirs that actually contain a `Project.toml` (`/`, `/docs`, `/test/GPU` — the old `/test` had no manifest).
- **typos**: 0 fixes needed (already clean).
- **Runic**: ran `Runic.main(["--inplace","."])` — no formatting changes (repo already clean).
- No `CompatHelper.yml` present.

## Heads-up
Check **names change** (now produced by the reusable workflows, e.g. "Runic Format Check", "Spell Check with Typos", "Downgrade Tests - Core"). Branch-protection required-status-check entries will need updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)