### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,20 +20,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,3 @@
+[Core]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]


### PR DESCRIPTION
Converts the root **Tests.yml** test workflow to the canonical thin caller of `SciML/.github` `grouped-tests.yml@v1`, with the version/OS matrix declared once in a ROOT `test/test_groups.toml`.

## Change

- `.github/workflows/Tests.yml`: the hand-maintained `version × os` matrix job is replaced by the thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  Filename and top-level `name: "Tests"` are preserved so branch-protection status checks stay valid. `on:` triggers (`pull_request`/`push` on `master` with `paths-ignore: docs/**`, plus the weekly `schedule`) and the `concurrency:` block are kept verbatim. No `with:` inputs are needed: the package reads the standard `GROUP` env var, `check-bounds` default (`yes`), coverage default (`true`), and `coverage-directories` default (`src,ext`, matching `src/` + `ext/`); there are no apt packages.
- `test/test_groups.toml` (new): a single capitalized `Core` group declaring the matrix.

```toml
[Core]
versions = ["lts", "1", "pre"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]
```

## Matrix match: 9/9 exact

The old job ran the full suite (GROUP defaulting to `"All"`) on `version ∈ {1, lts, pre} × os ∈ {ubuntu-latest, macos-latest, windows-latest}` = 9 cells.

`scripts/compute_affected_sublibraries.jl <root> --root-matrix` against the new TOML emits exactly 9 `(Core, version, runner)` cells covering the same `{lts,1,pre} × {ubuntu, macos, windows}` set. `runtests.jl` already dispatches the identical testset list for both `"All"` and `"Core"` (`GROUP == "All" || GROUP == "Core"`), so the per-cell behavior is preserved — the only change is the dispatched `GROUP` string going from the implicit `All` to `Core`. The TOML and YAML both parse cleanly.

## Category A / QA

This repo already has `Core`/`GPU` GROUP dispatch in `runtests.jl`, and QA (Aqua + ExplicitImports via `qa.jl`/`explicit_imports.jl`) runs inline as part of the `Core` path — there is no separate `QA` GROUP branch, so no `runtests.jl` change was made and no separate QA group was added (that would require a source change). Static matrix-verify only; no QA findings.

Untouched: `GPU.yml`, `Downgrade.yml`, `Documentation.yml`, `FormatCheck.yml`, `RunicSuggestions.yml`, `SpellCheck.yml`, `TagBot.yml`, `DocPreviewCleanup.yml`, `DependabotAutoMerge.yml`.

Ignore until reviewed by @ChrisRackauckas.