### PR TITLE
Support DiffCache for nonzeroable element types

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -88,10 +88,14 @@ end
 function DiffCache(u::AbstractArray{T}, siz, chunk_sizes; warn_on_resize::Bool = true) where {T}
     x = adapt(
         ArrayInterface.parameterless_type(u),
-        zeros(T, prod(chunk_sizes .+ 1) * prod(siz))
+        _zeroed_or_uninitialized(T, prod(chunk_sizes .+ 1) * prod(siz))
     )
     xany = Any[]
     return DiffCache(u, x, xany, warn_on_resize)
+end
+
+function _zeroed_or_uninitialized(::Type{T}, dims...) where {T}
+    return hasmethod(zero, Tuple{Type{T}}) ? zeros(T, dims...) : Array{T}(undef, dims...)
 end
 
 """

--- a/test/core_dispatch.jl
+++ b/test/core_dispatch.jl
@@ -33,6 +33,22 @@ end
 
 Base.zero(::Type{IsbitsPair{T}}) where {T} = IsbitsPair(zero(T), zero(T))
 
+@testset "DiffCache accepts isbits elements without zero" begin
+    u = [(; a = 1.0, b = (2.0, 3.0)), (; a = 4.0, b = (5.0, 6.0))]
+    cache = DiffCache(u, 3)
+    DualT = ForwardDiff.Dual{Nothing, Float64, 3}
+    tmp = get_tmp(cache, DualT)
+    expected_eltype = NamedTuple{(:a, :b), Tuple{DualT, Tuple{DualT, DualT}}}
+
+    @test eltype(cache.dual_du) == eltype(u)
+    @test length(cache.dual_du) == 8
+    @test size(tmp) == size(u)
+    @test eltype(tmp) == expected_eltype
+
+    tmp[1] = (; a = zero(DualT), b = (zero(DualT), zero(DualT)))
+    @test tmp[1] == (; a = zero(DualT), b = (zero(DualT), zero(DualT)))
+end
+
 #Setup Base Array tests
 chunk_size = 5
 u0 = ones(5, 5)


### PR DESCRIPTION
## Summary
- allow `DiffCache` backing storage to fall back to uninitialized storage when `zero(T)` is unavailable
- preserve zero-filled backing storage for element types that still support `zero(T)`
- add a regression test for an isbits named-tuple element with nested tuple fields under ForwardDiff dual replacement

## Motivation
`DiffCache(ar_alloc)` in #71 failed in the constructor because `zeros(T, ...)` requires `zero(::Type{T})`. Named tuples do not provide that method even when they are isbits and usable as cache elements.

## Validation
- Reproducer for a `Vector` of named tuples now constructs `DiffCache` and prints the expected cache length and element type.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e ... Pkg.test()` passed.
- `Runic.main(["--check", "."])` on Julia 1.10 passed.

This PR should be ignored until reviewed by @ChrisRackauckas.

Fixes #71.