### PR TITLE
Fix runtime full-size allocation in LazyBufferCache type assertion

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -278,9 +278,19 @@ function similar_type(x::AbstractArray{T}, s::NTuple{N, Integer}) where {T, N}
     return typeof(similar(x, ntuple(Returns(1), N)))
 end
 
-# Compute the type that `_make_buffer` would return for a given array and size.
-# When size matches the original, preserve the original type
-_buffer_type(x::AbstractArray, s) = s == size(x) ? typeof(similar(x)) : similar_type(x, s)
+# `similar(x)` preserves wrapper types (e.g. ComponentArrays) that dims-based
+# `similar(x, dims)` can strip, so its type is what the size-match branch of the
+# `get!` in `get_tmp` returns. The allocation is used only for its type: inference
+# resolves the result to a constant, and `:removable` lets the compiler delete the
+# full-size runtime allocation, which Julia 1.10/1.11 otherwise perform on every
+# `get_tmp` lookup (1.12+ elides it without the annotation).
+Base.@assume_effects :removable _preserved_similar_type(x::AbstractArray) = typeof(similar(x))
+
+# Compute the type that the buffer creation in `get_tmp` would return for a given
+# array and size. When size matches the original, preserve the original type.
+function _buffer_type(x::AbstractArray, s)
+    return s == size(x) ? _preserved_similar_type(x) : similar_type(x, s)
+end
 
 function get_tmp(
         b::LazyBufferCache, u::T, s = b.sizemap(size(u))

--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -1,16 +1,19 @@
 # Allocation regression tests for PreallocationTools.jl
 # These tests ensure that key functions remain zero-allocation at runtime.
-# Note: On Julia 1.10, some type assertions cannot be constant-folded,
-# causing small allocations. These tests are marked as broken on 1.10.
 
 using Test
 using PreallocationTools
 using ForwardDiff
 
-# Helper macro for allocation tests that may fail on Julia 1.10
+# The `Dual`/scalar `get_tmp` paths return small wrapper objects (ReinterpretArray,
+# SubArray, ReshapedArray) or box scalars. On Julia 1.10 and 1.11 the optimizer
+# heap-allocates these O(1), constant-size wrappers (16-176 bytes, no data copies)
+# even when the result is discarded; Julia 1.12's improved escape analysis elides
+# them. The wrappers are the return value of the API, so the allocation cannot be
+# avoided in package code on the older versions.
 macro test_alloc(expr)
     return quote
-        if VERSION >= v"1.11"
+        if VERSION >= v"1.12"
             @test $(esc(expr)) == 0
         else
             @test_broken $(esc(expr)) == 0
@@ -91,13 +94,12 @@ end
         get_tmp(lbc, u_mat)
 
         # Test zero allocations on subsequent calls
-        # On Julia 1.10, the _buffer_type type assertion cannot be constant-folded
-        @test_alloc (@allocated get_tmp(lbc, u_vec))
-        @test_alloc (@allocated get_tmp(lbc, u_mat))
+        @test (@allocated get_tmp(lbc, u_vec)) == 0
+        @test (@allocated get_tmp(lbc, u_mat)) == 0
 
         # Test with getindex syntax
-        @test_alloc (@allocated lbc[u_vec])
-        @test_alloc (@allocated lbc[u_mat])
+        @test (@allocated lbc[u_vec]) == 0
+        @test (@allocated lbc[u_mat]) == 0
     end
 
     @testset "LazyBufferCache with size mapping" begin

--- a/test/general_lbc.jl
+++ b/test/general_lbc.jl
@@ -44,21 +44,10 @@ solve(prob, LBFGS())
 cache = LazyBufferCache()
 x = rand(1000)
 @inferred cache[x]
-# On Julia 1.10, the _buffer_type type assertion can't be constant-folded
-# due to the runtime s == size(x) comparison, causing allocations.
-# This is a performance regression on 1.10 only; functionality is correct.
-if VERSION >= v"1.11"
-    @test 0 == @allocated cache[x]
-else
-    @test_broken 0 == @allocated cache[x]
-end
+@test 0 == @allocated cache[x]
 y = view(x, 1:900)
 @inferred cache[y]
-if VERSION >= v"1.11"
-    @test 0 == @allocated cache[y]
-else
-    @test_broken 0 == @allocated cache[y]
-end
+@test 0 == @allocated cache[y]
 @test cache[y] === get_tmp(cache, y)
 
 @inferred cache[x, 1111]


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

`GROUP=Core Pkg.test()` fails on Julia 1.11.9 (a version not in the CI matrix, which runs lts=1.10, 1=1.12, pre=1.13): the `GeneralLazyBufferCache` safetestset fails `@test 0 == @allocated cache[x]` / `@test 0 == @allocated cache[y]` in `test/general_lbc.jl`, with ~8 KB allocated per `LazyBufferCache` lookup, and the `Allocation Regression Tests` safetestset fails 6 more `@test_alloc` assertions on the `Dual`/scalar `get_tmp` paths.

## Root cause 1: `_buffer_type` executes a full-size `similar` at runtime (bisected to 327bfb1)

Bisect result: the parent of 327bfb1 has zero-allocation `get_tmp(::LazyBufferCache, u)` on Julia 1.10.11, 1.11.9, and 1.12.6; 327bfb1 ("Preserve wrapper array types in LazyBufferCache when size matches") allocates on 1.10 and 1.11 (8040 bytes for a `Vector{Float64}(1000)` lookup — exactly one full-size buffer per call).

327bfb1 changed the type assertion from `similar_type(u, s)` (which calls `similar(x, (1,...,1))` with constant dims, elidable by all supported compilers) to `typeof(similar(x))` (runtime dims). The allocation's only use is `typeof`, and inference resolves the assertion to a constant, but the 1.10/1.11 optimizers cannot delete the full-size runtime allocation; 1.12+ elides it via escape analysis.

The `@test_broken` gating added for 1.10 in 897efe2 was papering over this same regression (its comment blamed a 1.10 compiler limitation, but 1.10 had zero allocations before 327bfb1). Since 1.11 is not in CI, the 1.11 breakage went unnoticed.

**Fix:** move `typeof(similar(x))` into a helper annotated `Base.@assume_effects :removable`, so the compiler may delete the call once inference has resolved the result to a constant. Wrapper-type preservation (the purpose of 327bfb1, e.g. ComponentArrays) is unchanged — the `WrapperArray` regression test in `test/lbc.jl` still passes. The version gates in `test/general_lbc.jl` are removed since the tests now genuinely pass on all supported versions.

## Root cause 2: `@test_alloc` gate at 1.11 was wrong

The remaining 6 failures on 1.11.9 (`get_tmp` with `Dual` arrays and scalars on `DiffCache`/`FixedSizeDiffCache`) predate 327bfb1 — verified by running them against 327bfb1's parent on 1.11.9 (same 16-176 byte allocations). These paths return small wrapper objects (`ReinterpretArray`, `SubArray`) or boxed scalars that the 1.10 **and** 1.11 optimizers heap-allocate even when the result is discarded; 1.12's escape analysis elides them. The wrapper is the API's return value, so this is not fixable in package code on the older versions. The gate is moved from `VERSION >= v"1.11"` to `VERSION >= v"1.12"` with a comment documenting the justification (these are O(1) wrapper allocations, not data copies).

## Verification (all run locally)

`GROUP=Core Pkg.test()` on this branch:

| Julia | GeneralLazyBufferCache | Allocation Regression Tests | Overall |
|---|---|---|---|
| 1.10.11 | 11/11 pass | 21 pass, 6 broken | pass |
| 1.11.9 | 11/11 pass | 21 pass, 6 broken | pass |
| 1.12.6 | 11/11 pass | 27/27 pass | pass |

On unmodified master, 1.11.9 fails (GeneralLazyBufferCache 9 pass / 2 fail, plus 6 failures in alloc_tests.jl); 1.10/1.12 pass only because the failures were gated or version-specific.

Standalone allocation check of the fixed `get_tmp(::LazyBufferCache, ...)` also confirmed 0 bytes on 1.10.11, 1.11.9, 1.12.6, and 1.13.0-rc1.

Runic formatting applied to all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5nf9KF4RRs1cpmjxG3NQe