### PR TITLE
Fix get_tmp nesting duals when the DiffCache base eltype is already Dual

### DIFF
--- a/ext/PreallocationToolsForwardDiffExt.jl
+++ b/ext/PreallocationToolsForwardDiffExt.jl
@@ -27,6 +27,12 @@ PreallocationTools.chunksize(::Type{ForwardDiff.Dual{T, V, N}}) where {T, V, N} 
 function dual_eltype(::Type{CacheT}, ::Type{DualT}) where {
         CacheT, Tag, V, N, DualT <: ForwardDiff.Dual{Tag, V, N},
     }
+    # A `Dual`-eltype cache means the base buffer was allocated at an outer
+    # dual level (AD-over-AD, e.g. `DiffCache(similar(u))` while
+    # ForwardDiff-ing through a solver). The requested dual type must then be
+    # returned as-is: recursing into `CacheT`'s type parameters would re-tag
+    # its value type and fabricate a nested dual the caller never asked for.
+    CacheT <: ForwardDiff.Dual && return DualT
     dual_cache_t = replace_type_parameter(CacheT, V, DualT)
     return dual_cache_t === CacheT ? DualT : dual_cache_t
 end

--- a/ext/PreallocationToolsForwardDiffExt.jl
+++ b/ext/PreallocationToolsForwardDiffExt.jl
@@ -33,13 +33,35 @@ function dual_eltype(::Type{CacheT}, ::Type{DualT}) where {
     # returned as-is: recursing into `CacheT`'s type parameters would re-tag
     # its value type and fabricate a nested dual the caller never asked for.
     CacheT <: ForwardDiff.Dual && return DualT
+    # The wrapper analog of the same situation: a cache eltype like
+    # `Complex{Dual{Tag, V, N}}` that already contains the requested dual is
+    # already at the requested level — replacing inside it would rewrite the
+    # dual's tag/value parameters and fabricate nesting one wrapper deeper.
+    type_contains(CacheT, DualT) && return CacheT
     dual_cache_t = replace_type_parameter(CacheT, V, DualT)
     return dual_cache_t === CacheT ? DualT : dual_cache_t
+end
+
+function _type_contains(T, X)
+    T === X && return true
+    T isa DataType || return false
+    return any(p -> p isa Type && _type_contains(p, X), T.parameters)
+end
+# @generated so the recursive parameter walk runs at compile time and folds to
+# a constant — a runtime svec iteration here would allocate in the `get_tmp`
+# hot path. (`_type_contains` must be defined above: generated function bodies
+# may only call functions from an older world age.)
+@generated function type_contains(::Type{T}, ::Type{X}) where {T, X}
+    return _type_contains(T, X)
 end
 
 function replace_type_parameter(::Type{T}, ::Type{From}, ::Type{To}) where {T, From, To}
     T === From && return To
     T <: Number && From <: Number && promote_type(T, From) === From && return To
+    # Duals are atomic: replace them whole (the matches above) or leave them
+    # alone. Recursing into a Dual's parameters would rewrite its Tag's value
+    # type, silently breaking ForwardDiff's tag matching.
+    T <: ForwardDiff.Dual && return T
 
     typename = Base.typename(T)
     wrapper = typename.wrapper
@@ -56,13 +78,34 @@ end
 function diffcache_dual_tmp(dc::PreallocationTools.DiffCache, ::Type{T}) where {T <: ForwardDiff.Dual}
     cache_eltype = dual_eltype(eltype(dc.du), T)
     return if isbitstype(cache_eltype)
-        nelem = div(sizeof(cache_eltype), sizeof(eltype(dc.dual_du))) * length(dc.du)
-        if nelem > length(dc.dual_du)
-            PreallocationTools.enlargediffcache!(dc, nelem)
+        # Branch on a type-level size condition so it constant-folds per
+        # specialization (each call site sees exactly one branch — keeping the
+        # common path type-stable and allocation-free, bit-identical to the
+        # original code).
+        if sizeof(cache_eltype) % sizeof(eltype(dc.dual_du)) == 0
+            nelem = div(sizeof(cache_eltype), sizeof(eltype(dc.dual_du))) *
+                length(dc.du)
+            if nelem > length(dc.dual_du)
+                PreallocationTools.enlargediffcache!(dc, nelem)
+            end
+            PreallocationTools._restructure(
+                dc.du, reinterpret(cache_eltype, view(dc.dual_du, 1:nelem))
+            )
+        else
+            # A resolved eltype SMALLER than (or not a multiple of) the storage
+            # eltype — e.g. a bare-dual fallback against a wrapper-of-dual
+            # buffer. The per-element `div` ratio floors to zero there, so use
+            # ceiling byte arithmetic and take exactly `length(du)` elements
+            # (the ceiling can over-cover by a fraction of an element).
+            nelem = cld(
+                sizeof(cache_eltype) * length(dc.du), sizeof(eltype(dc.dual_du))
+            )
+            if nelem > length(dc.dual_du)
+                PreallocationTools.enlargediffcache!(dc, nelem)
+            end
+            reint = reinterpret(cache_eltype, view(dc.dual_du, 1:nelem))
+            PreallocationTools._restructure(dc.du, view(reint, 1:length(dc.du)))
         end
-        PreallocationTools._restructure(
-            dc.du, reinterpret(cache_eltype, view(dc.dual_du, 1:nelem))
-        )
     else
         PreallocationTools._restructure(dc.du, zeros(cache_eltype, size(dc.du)))
     end

--- a/test/core_dispatch.jl
+++ b/test/core_dispatch.jl
@@ -270,3 +270,37 @@ end
     nested = get_tmp(dc, zeros(NestedDual, 5))
     @test eltype(nested) === NestedDual
 end
+
+@testset "wrapper-of-Dual cache eltypes do not nest or corrupt tags" begin
+    # An isbits wrapper containing a dual as the cache base eltype (e.g. a
+    # complex-valued buffer allocated under an outer AD pass). A same-level
+    # dual request must return the cache's own eltype — descending into the
+    # stored dual would rewrite its Tag's value type (breaking ForwardDiff tag
+    # matching) and fabricate nesting one wrapper deeper.
+    D1 = ForwardDiff.Dual{ForwardDiff.Tag{:L1, Float64}, Float64, 3}
+    D2 = ForwardDiff.Dual{ForwardDiff.Tag{:L2, D1}, D1, 2}
+    D3 = ForwardDiff.Dual{ForwardDiff.Tag{:L3, D2}, D2, 4}
+
+    dc1 = DiffCache(zeros(Complex{D1}, 4), 3)
+    @test eltype(get_tmp(dc1, zeros(D1, 4))) === Complex{D1}       # same level
+    @test eltype(get_tmp(dc1, zeros(D2, 4))) === Complex{D2}       # genuinely nested
+    @test eltype(get_tmp(dc1, first(zeros(D1, 4)))) === Complex{D1}
+
+    dc2 = DiffCache(zeros(Complex{D2}, 4), 2)
+    @test eltype(get_tmp(dc2, zeros(D2, 4))) === Complex{D2}       # same level, depth 2
+    @test eltype(get_tmp(dc2, zeros(D3, 4))) === Complex{D3}       # deeper still
+
+    # A same-level request with a DIFFERENT tag (sibling AD) cannot be
+    # composed meaningfully with the stored dual; it must fall back to the
+    # bare requested dual with the stored dual left untouched — never a
+    # rewritten-tag hybrid.
+    D1b = ForwardDiff.Dual{ForwardDiff.Tag{:sibling, Float64}, Float64, 3}
+    T_sib = eltype(get_tmp(dc1, zeros(D1b, 4)))
+    @test T_sib === D1b
+
+    # plain-wrapper composition still works at every depth
+    dc0 = DiffCache(zeros(ComplexF64, 4), 3)
+    @test eltype(get_tmp(dc0, zeros(D1, 4))) === Complex{D1}
+    @test eltype(get_tmp(dc0, zeros(D2, 4))) === Complex{D2}
+    @test eltype(get_tmp(dc0, zeros(D3, 4))) === Complex{D3}
+end

--- a/test/core_dispatch.jl
+++ b/test/core_dispatch.jl
@@ -248,3 +248,25 @@ dl = zeros(ForwardDiff.Dual{Nothing, Float64, 3}, 3)
     complex32_tmp = get_tmp(complex32_cache, DualT)
     @test eltype(complex32_tmp) == Complex{DualT}
 end
+
+@testset "DiffCache with Dual base eltype does not nest tags" begin
+    # AD-over-AD: the base buffer is allocated at an outer dual level (e.g.
+    # `DiffCache(similar(u))` while ForwardDiff-ing through a solver whose
+    # state was promoted to Dual). Requesting a buffer for the same dual type
+    # must return exactly that eltype, not a Dual re-tagged over the base.
+    OuterDual = ForwardDiff.Dual{ForwardDiff.Tag{:outer, Float64}, Float64, 3}
+    base = zeros(OuterDual, 5)
+    dc = DiffCache(base, 3)
+
+    same_level = get_tmp(dc, base)
+    @test eltype(same_level) === OuterDual
+
+    same_level_scalar = get_tmp(dc, first(base))
+    @test eltype(same_level_scalar) === OuterDual
+
+    # A genuinely nested request (inner AD over the outer-dual state) must
+    # still return the nested dual type unchanged.
+    NestedDual = ForwardDiff.Dual{ForwardDiff.Tag{:inner, OuterDual}, OuterDual, 2}
+    nested = get_tmp(dc, zeros(NestedDual, 5))
+    @test eltype(nested) === NestedDual
+end


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

v1.2.2 (#178) introduced `dual_eltype`/`replace_type_parameter` so that `DiffCache` preserves isbits wrapper eltypes (e.g. `Complex{Float64}` → `Complex{Dual}`). However, when the cache's base array itself has a `Dual` eltype — the AD-over-AD pattern where the base buffer is allocated at an outer dual level, e.g. `DiffCache(similar(u))` inside a solver whose state was promoted to `Dual` by an outer `ForwardDiff.gradient` — `replace_type_parameter` recurses *into the `Dual`'s own type parameters* and re-tags its value type. Requesting a buffer for the very same dual type then returns a spuriously **nested** dual:

```julia
OuterDual = ForwardDiff.Dual{ForwardDiff.Tag{:outer, Float64}, Float64, 3}
dc = DiffCache(zeros(OuterDual, 5), 3)
eltype(get_tmp(dc, zeros(OuterDual, 5)))
# v1.2.1: OuterDual (correct)
# v1.2.2: Dual{Tag{:outer, OuterDual}, OuterDual, 3}  (nested, wrong)
```

The fix: when the cache eltype is itself a `Dual`, return the requested dual type unchanged (the pre-1.2.2 behavior). The #178 wrapper replacement is preserved for non-`Dual` cache eltypes; genuinely nested requests (inner AD over the outer-dual state) still return the nested type unchanged.

## Downstream breakage this fixes

The v1.2.2 release (registered 2026-07-10, a few hours after the last green OrdinaryDiffEq master CI run) broke the `OrdinaryDiffEqRosenbrock` group on SciML/OrdinaryDiffEq.jl master. In `lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl`, the two cases

- `IIP=false Brown=true AD=AutoForwardDiff(chunksize=3) Alg=Rodas5P`
- `IIP=false Brown=true AD=AutoForwardDiff(chunksize=3) Alg=Tsit5DA`

error with

```
MethodError: no method matching Float64(::ForwardDiff.Dual{ForwardDiff.Tag{var"#f#...", ForwardDiff.Dual{...}}, ForwardDiff.Dual{...}, 3})
```

inside `mul!` in NonlinearSolveBase's `NewtonDescent`, reached via `_initialize_dae!` (out-of-place `BrownFullBasicInit`, `lib/OrdinaryDiffEqNonlinearSolve/src/initialize_dae.jl`). That path does `_tmp = DiffCache(similar(u0), chunk)` where `u0` is the outer-dual-promoted state and `uu = get_tmp(_tmp, x)` in the nonlinear residual; with v1.2.2 `uu` gets the nested eltype, the residual returns nested duals, and they hit the Float64/outer-dual buffers of the NonlinearSolve cache. The failing `@safetestset` also aborts the rest of the Rosenbrock Core group.

Bisection over package versions (same OrdinaryDiffEq master checkout, everything else held fixed, including SciMLBase pinned at 3.33.0): PreallocationTools 1.2.1 → passes; 1.2.2 → fails.

## Local verification (Julia 1.12.4)

- `julia -e 'using Runic; exit(Runic.main(ARGS))' -- --check ext/PreallocationToolsForwardDiffExt.jl test/core_dispatch.jl` — clean.
- `julia --project=. -e 'using Pkg; Pkg.test()'` — all pass:

  ```
  DiffCache Dispatch                      |   73  Pass  10 Broken (the pre-existing @test_broken)
  DiffCache ODE tests                     |    7  Pass
  DiffCache Resizing                      |   64  Pass
  DiffCache Nested Duals                  |    4  Pass
  DiffCache Sparsity Support              |    4  Pass
  DiffCache with SparseConnectivityTracer |   10  Pass
  LazyBufferCache                         |    2  Pass
  GeneralLazyBufferCache                  |   11  Pass
  Zero, Copy, and Fill Dispatches         |   64  Pass
  Allocation Regression Tests             |   27  Pass
       Testing PreallocationTools tests passed
  ```

- OrdinaryDiffEq master with this branch `Pkg.develop`ed: the previously failing `lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl` now passes:

  ```
  Test Summary:           | Pass  Total      Time
  DAE Rosenbrock AD Tests |   16     16  12m51.5s
  ```

  On master with PreallocationTools v1.2.2 this is 14 Pass / 2 Error; OrdinaryDiffEq master Sublibrary CI run 29116790364/29116790303 now shows the same Rosenbrock Core failure on Julia 1, lts, and pre.

Root-cause investigation notes: the failure was reproduced on unmodified OrdinaryDiffEq master (Julia 1.12.4), narrowed to a single `DI.gradient(p -> solve(remake(prob; p), Rodas5P(autodiff=AutoForwardDiff(chunksize=3)); initializealg=BrownFullBasicInit()), AutoForwardDiff(), p0)` call, instrumented to show `get_tmp` returning the nested eltype, and A/B-flipped on the PreallocationTools version alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
