### PR TITLE
Remove the makeshadow inlining workaround once EnzymeAD/Enzyme.jl#3322 is fixed

### DIFF
--- a/ext/PreallocationToolsEnzymeCoreExt.jl
+++ b/ext/PreallocationToolsEnzymeCoreExt.jl
@@ -50,21 +50,10 @@ shadowkey(b::LazyBufferCache) = b.bufs
 
 # `warn_on_resize = false`: the primal cache already warns if it is enlarged;
 # a second warning from the hidden shadow cache would be confusing.
-# `@inline`: under nested differentiation these run inside Enzyme-compiled
-# code, and Enzyme's module type-classification cannot parse standalone
-# functions returning immutable structs with mixed pointer/isbits fields on
-# Julia <= 1.11 (sret+returnroots CallingConventionMismatchError); inlined
-# into `constshadow` no such function exists in the module.
-@inline makeshadow(dc::DiffCache) = DiffCache(
-    zero(dc.du), zero(dc.dual_du), Any[], false
-)
-@inline makeshadow(dc::FixedSizeDiffCache) = FixedSizeDiffCache(
-    zero(dc.du), zero(dc.dual_du), Any[]
-)
+makeshadow(dc::DiffCache) = DiffCache(zero(dc.du), zero(dc.dual_du), Any[], false)
+makeshadow(dc::FixedSizeDiffCache) = zero(dc)
 zeroinit!(buf) = fill!(buf, zero(eltype(buf)))
-@inline makeshadow(b::LazyBufferCache) = LazyBufferCache(
-    b.sizemap; initializer! = zeroinit!
-)
+makeshadow(b::LazyBufferCache) = LazyBufferCache(b.sizemap; initializer! = zeroinit!)
 
 shadowfits(s::DiffCache, dc::DiffCache) = size(s.du) == size(dc.du)
 shadowfits(s::FixedSizeDiffCache, dc::FixedSizeDiffCache) = size(s.du) == size(dc.du)


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until EnzymeAD/Enzyme.jl#3322 is fixed and released.** This PR should be ignored until reviewed by @ChrisRackauckas.

Follow-up to #183: removes the last Enzyme-bug workaround remaining in the EnzymeCore extension — the `@inline` annotations on the three `makeshadow` helpers (and restores `zero(dc)` for the `FixedSizeDiffCache` case).

The annotations exist because Enzyme's module type-classification on Julia ≤ 1.11 cannot parse standalone functions returning immutable structs with mixed pointer/isbits fields when they end up inside a nested-differentiation module (`CallingConventionMismatchError` in `classify_arguments`, [EnzymeAD/Enzyme.jl#3322](https://github.com/EnzymeAD/Enzyme.jl/issues/3322)). Inlining them makes the standalone functions disappear from the module.

**Current state (verified locally against Enzyme v0.13.181):**

- Julia 1.12: 26/26 pass (the nested testset is gated there by EnzymeAD/Enzyme.jl#3315, unrelated).
- Julia 1.11: the "Second order: Enzyme over Enzyme" testset fails with exactly the #3322 `CallingConventionMismatchError` — the single expected failure. The lts CI lane will be red for the same reason.

This PR therefore functions as a canary: when an Enzyme release fixes #3322, re-running CI (which resolves the latest Enzyme) should turn it green. **Before merging:** bump the `Enzyme` entry in `[compat]` to the release containing the fix, mirroring what #183 did for 0.13.181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5nf9KF4RRs1cpmjxG3NQe
