### PR TITLE
Enable rendered public docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,6 +3,7 @@ using SciMLTesting, PreallocationTools, Test
 run_qa(
     PreallocationTools;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (; ambiguities = (; recursive = false)),
     ei_kwargs = (;
         # The package extensions load (and are analyzed by ExplicitImports) whenever


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- enable SciMLTesting rendered public-docs QA for PreallocationTools

## Validation
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'` passed: Quality Assurance 17/17, AllocCheck 7/7
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'` passed with only local deploy warning
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test()'` passed; initial active-manifest warning/precompile failure re-resolved in the temporary test env, final package tests passed
- `timeout 3600 /home/crackauc/.julia/packages/Runic/XIBDc/bin/runic --check .` passed