### PR TITLE
Make the QA group scan all four package extensions

### DIFF
--- a/ext/PreallocationToolsForwardDiffExt.jl
+++ b/ext/PreallocationToolsForwardDiffExt.jl
@@ -1,10 +1,9 @@
 module PreallocationToolsForwardDiffExt
 
 using PreallocationTools
-using ForwardDiff
-using ArrayInterface
-using Adapt
-using PrecompileTools
+using ForwardDiff: ForwardDiff
+using ArrayInterface: ArrayInterface
+using PrecompileTools: @setup_workload, @compile_workload
 
 function PreallocationTools.dualarraycreator(
         u::AbstractArray{T}, siz,
@@ -72,7 +71,7 @@ function replace_type_parameter(::Type{T}, ::Type{From}, ::Type{To}) where {T, F
         parameter isa Type ? replace_type_parameter(parameter, From, To) : parameter
     end
 
-    return new_parameters == parameters ? T : Core.apply_type(wrapper, new_parameters...)
+    return new_parameters == parameters ? T : wrapper{new_parameters...}
 end
 
 function diffcache_dual_tmp(dc::PreallocationTools.DiffCache, ::Type{T}) where {T <: ForwardDiff.Dual}

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,15 +1,23 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AllocCheck = "0.2"
 Aqua = "0.8.11"
+EnzymeCore = "0.8"
+ForwardDiff = "0.10.38, 1.0.1"
+ReverseDiff = "1.16"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
+SparseConnectivityTracer = "1"
 Test = "1.10"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,48 @@
 using SciMLTesting, PreallocationTools, Test
 
-run_qa(PreallocationTools)
+# ExplicitImports only checks an extension module once it has been loaded, which
+# requires its trigger package to be present. Loading every weakdep here puts all
+# four extensions under the QA checks.
+using EnzymeCore, ForwardDiff, ReverseDiff, SparseConnectivityTracer
+
+run_qa(
+    PreallocationTools;
+    ei_kwargs = (;
+        all_explicit_imports_are_public = (;
+            ignore = (
+                # EnzymeCore neither exports nor declares `EnzymeRules` public,
+                # yet the submodule is the only entry point for defining Enzyme
+                # custom rules.
+                :EnzymeRules,
+                # SparseConnectivityTracer exports only its detectors and
+                # sparsity entry points. `AbstractTracer` and `Dual` are the
+                # types a `get_tmp` method has to dispatch on for sparsity
+                # detection to reach the cache, and neither has a public name.
+                :AbstractTracer, :Dual,
+            ),
+        ),
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                # `EnzymeCore.EnzymeRules` declares `forward`,
+                # `augmented_primal` and `reverse` as bare `function ... end`
+                # stubs without exporting them. Adding methods to them is the
+                # documented way to write a custom rule.
+                :forward, :augmented_primal, :reverse,
+                # ForwardDiff exports only `DiffResults`. `Dual` is the type
+                # every dual-cache method dispatches on and `pickchunksize` is
+                # the chunk heuristic the cache sizing mirrors.
+                :Dual, :pickchunksize,
+                # ReverseDiff likewise exports only `DiffResults`;
+                # `TrackedArray` is the type the LazyBufferCache method keys on.
+                :TrackedArray,
+                # `Base.typename` is the only way to recover a DataType's
+                # UnionAll wrapper so its type parameters can be substituted;
+                # Base offers no public equivalent.
+                :typename,
+            ),
+        ),
+    )
+)
 
 @testset "AllocCheck" begin
     include("allocation_tests.jl")


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Why

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module.
ExplicitImports *does* know about extensions — it reads the `[extensions]` table out
of `Project.toml` — but it only checks an extension module that actually exists:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only comes into existence once its trigger weakdep is loaded, and
the QA environment loaded none of them. **Today no PreallocationTools extension is
scanned by QA at all.** The fix is to put the weakdeps in `test/qa/Project.toml` and
`using` them in `test/qa/qa.jl` before `run_qa`.

## Coverage

All four weakdeps are pure Julia and resolve cleanly, so **all four extensions are now
scanned** — nothing is left out:

| Extension | Trigger | Now scanned |
| --- | --- | --- |
| `PreallocationToolsEnzymeCoreExt` | EnzymeCore | yes |
| `PreallocationToolsForwardDiffExt` | ForwardDiff | yes |
| `PreallocationToolsReverseDiffExt` | ReverseDiff | yes |
| `PreallocationToolsSparseConnectivityTracerExt` | SparseConnectivityTracer | yes |

`[compat]` entries in `test/qa/Project.toml` mirror the root package's bounds
(`EnzymeCore = "0.8"`, `ForwardDiff = "0.10.38, 1.0.1"`, `ReverseDiff = "1.16"`,
`SparseConnectivityTracer = "1"`).

## Fixed in the extension source (not ignored)

Two findings had a public spelling, so the source was fixed rather than ignored:

* **`no_implicit_imports`** — `PreallocationToolsForwardDiffExt` did bare
  `using ForwardDiff` / `using ArrayInterface` / `using PrecompileTools` and then
  referred to `ForwardDiff.Dual`, `ArrayInterface.restructure`, `@setup_workload` and
  `@compile_workload`. These are now `using ForwardDiff: ForwardDiff`,
  `using ArrayInterface: ArrayInterface` and
  `using PrecompileTools: @setup_workload, @compile_workload`.
  `using Adapt` is **dropped**: the extension never referenced Adapt (it is used only
  in `src/PreallocationTools.jl`), so keeping it as an explicit import would have
  tripped `no_stale_explicit_imports`.
* **`all_qualified_accesses_are_public`: `Core.apply_type`** — replaced with
  `wrapper{new_parameters...}`, which is exactly the same operation spelled with public
  syntax (`Core.apply_type` is the intrinsic behind `T{...}`).

## Ignore entries added, with justification

Every remaining finding is a name that is genuinely non-public at its owner and has no
public equivalent. Each is grouped under a comment naming the owner in `qa.jl`.

`all_explicit_imports_are_public`:

| Symbol | Owner | Why unavoidable |
| --- | --- | --- |
| `:EnzymeRules` | EnzymeCore | EnzymeCore neither exports nor declares the submodule public, yet it is the only entry point for defining Enzyme custom rules. |
| `:AbstractTracer`, `:Dual` | SparseConnectivityTracer | SCT exports only `TracerSparsityDetector`, `TracerLocalSparsityDetector`, `jacobian_sparsity`, `hessian_sparsity`, `jacobian_eltype`, `hessian_eltype`, `jacobian_buffer`, `hessian_buffer`. These two types are what a `get_tmp` method must dispatch on for sparsity detection to reach the cache. |

`all_qualified_accesses_are_public`:

| Symbol | Owner | Why unavoidable |
| --- | --- | --- |
| `:forward`, `:augmented_primal`, `:reverse` | `EnzymeCore.EnzymeRules` | Declared as bare `function ... end` stubs and not exported. Adding methods to them *is* the documented way to write a custom rule. |
| `:Dual`, `:pickchunksize` | ForwardDiff | ForwardDiff exports only `DiffResults`. `Dual` is the type every dual-cache method dispatches on; `pickchunksize` is the chunk heuristic the cache sizing mirrors. |
| `:TrackedArray` | ReverseDiff | ReverseDiff also exports only `DiffResults`; `TrackedArray` is the type the `LazyBufferCache` method keys on. |
| `:typename` | Base | The only way to recover a `DataType`'s `UnionAll` wrapper so its type parameters can be substituted. Base offers no public equivalent. |

No check was disabled, and no `@test_broken` / `explicit_imports = false` escape hatch
was used.

## Local verification

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on this branch (Julia 1.12):

```
Test Summary: | Pass  Total     Time
QA            |   27     27  1m28.9s
     Testing PreallocationTools tests passed
```

(For reference, the same command with the weakdeps added but before the fixes reported
`24 passed, 3 errored`, which is the previously-invisible extension debt this PR pays
off.)

The `Core.apply_type` → `wrapper{...}` rewrite was additionally checked directly against
`replace_type_parameter` for `Float64`, `Complex{Float64}`, `Vector{Complex{Float64}}`
and `String`, all unchanged.

`test/qa/Manifest.toml` is a local build artifact and is not committed (`Manifest.toml`
is already in `.gitignore`). Runic was run on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7