### PR TITLE
Raise Symbolics test floor to 7.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,7 +42,7 @@ ReverseDiff = "1.16"
 SafeTestsets = "0.1"
 SparseArrays = "1.10"
 SparseConnectivityTracer = "1"
-Symbolics = "6.29.0, 7"
+Symbolics = "7.6"
 Test = "1.10"
 julia = "1.10"
 


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Follow-up to https://github.com/SciML/PreallocationTools.jl/pull/199. That PR unblocked LabelledArrays 1.16, and the next Downgrade job failed on Symbolics instead.

## What changed

Pure `[compat]` lower-bound bump for a test extra:

- `Project.toml`: `Symbolics = "6.29.0, 7"` → `"7.6"`

No library code, tests, or package version were changed. Symbolics is not a runtime dependency.

## Why

After #199, master Downgrade is still red while Tests on the same commit are not the failure mode:

- https://github.com/SciML/PreallocationTools.jl/actions/runs/31810178466

```
Unsatisfiable requirements detected for package PreallocationTools
 ├─PreallocationTools is fixed to version 1.5.0
 └─restricted by compatibility requirements with Symbolics to versions: uninstalled
   └─restricted to versions 6.29.0 by an explicit requirement
```

Symbolics WeakCompat still has `PreallocationTools = "0.4"` for `5.29 – 7.5`. 7.6 is the first release that allows PreallocationTools 1.x.

## Verification

Julia 1.10.11, `Pkg.develop` of this checkout, then `Pkg.add(name="Symbolics", version=...)`:

| Symbolics | Result |
|---|---|
| 6.29.0 (old floor) | unsatisfiable vs PreallocationTools 1.5.0 |
| 7.5.0 | unsatisfiable (still requires PreallocationTools 0.4) |
| 7.6.0 (new floor) | resolves |

Not verified here: a live `julia-downgrade-compat` run, or whether another extra floor is next after this one.
