### PR TITLE
Avoid ambiguous reverse promotion in DiffCache

### DIFF
--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -250,8 +250,14 @@ function get_tmp(dc::FixedSizeDiffCache, u::Union{Number, AbstractArray})
     return get_tmp(dc, eltype(u))
 end
 
+function _promotes_to_primal(::Type{P}, ::Type{T}) where {P, T}
+    # Query the requested type first so its custom rule can avoid an ambiguous reverse rule.
+    promoted = Base.promote_rule(T, P)
+    return promoted === Union{} ? promote_type(P, T) <: P : promoted <: P
+end
+
 function get_tmp(dc::FixedSizeDiffCache, ::Type{T}) where {T <: Number}
-    return if promote_type(eltype(dc.du), T) <: eltype(dc.du)
+    return if _promotes_to_primal(eltype(dc.du), T)
         dc.du
     else
         _typed_tmp(dc, T)
@@ -394,7 +400,7 @@ function _typed_tmp(dc, ::Type{T}) where {T}
 end
 
 function get_tmp(dc::DiffCache, u::Union{Number, AbstractArray})
-    return if promote_type(eltype(dc.du), eltype(u)) <: eltype(dc.du)
+    return if _promotes_to_primal(eltype(dc.du), eltype(u))
         dc.du
     else
         _typed_tmp(dc, eltype(u))
@@ -402,7 +408,7 @@ function get_tmp(dc::DiffCache, u::Union{Number, AbstractArray})
 end
 
 function get_tmp(dc::DiffCache, ::Type{T}) where {T <: Number}
-    return if promote_type(eltype(dc.du), T) <: eltype(dc.du)
+    return if _promotes_to_primal(eltype(dc.du), T)
         dc.du
     else
         _typed_tmp(dc, T)

--- a/test/sparse_connectivity_tracer.jl
+++ b/test/sparse_connectivity_tracer.jl
@@ -2,6 +2,18 @@ module TestSparseConnectivityTracer
 
 using PreallocationTools, SparseConnectivityTracer, ForwardDiff, SparseArrays, Test
 
+@testset "BigFloat cache" begin
+    T = jacobian_eltype(BigFloat[1], TracerLocalSparsityDetector())
+    input = Vector{T}(undef, 1)
+
+    for cache in (DiffCache(BigFloat[1]), FixedSizeDiffCache(BigFloat[1], 1))
+        type_workspace = @inferred get_tmp(cache, T)
+        array_workspace = @inferred get_tmp(cache, input)
+        @test eltype(type_workspace) === T
+        @test Base.mightalias(type_workspace, array_workspace)
+    end
+end
+
 function f1(u, cache)
     c = get_tmp(cache, u)
     # This will throw if a fallback definition is used


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What changed

`get_tmp` now asks the requested element type's public `Base.promote_rule` first. When that type has no rule, it falls back to the existing symmetric `promote_type` check. This preserves the primal buffer selection for ordinary inputs while avoiding an ambiguous reverse promotion rule for `BigFloat` and `SparseConnectivityTracer.Dual`.

The regression test covers both `DiffCache` and `FixedSizeDiffCache` through SparseConnectivityTracer's public `jacobian_eltype` API. No SparseConnectivityTracer dependency or internal API is added.

## Root cause

PreallocationTools v1.5.0 moved sparse-tracer handling into the generic cache path. `promote_type(BigFloat, SparseConnectivityTracer.Dual{BigFloat, ...})` asks both promotion directions; its reverse query is ambiguous between Base's `BigFloat` rule and SparseConnectivityTracer's `Dual` rule.

The boundary bisects to https://github.com/SciML/PreallocationTools.jl/commit/a032da6e40b36efcfa459d7530816b7b77d0bd2c (the merge of https://github.com/SciML/PreallocationTools.jl/pull/198). PreallocationTools v1.4.1 passes the standalone control; v1.5.0 fails.

## Failing before

```console
$ env JULIA_DEPOT_PATH=$DEPOT JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
BigFloat cache: Error During Test
MethodError: promote_rule(::Type{BigFloat}, ::Type{SparseConnectivityTracer.Dual{BigFloat, ...}}) is ambiguous.
Test Summary:             | Pass  Error  Total
Sparse Connectivity Tests |   22      1     23
ERROR: Package PreallocationTools errored during testing
```

The unmodified BoundaryValueDiffEq master `Misc` group reproduces the downstream failure with PreallocationTools v1.5.0 and SparseConnectivityTracer v1.2.2:

```console
$ env JULIA_DEPOT_PATH=$DEPOT JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=Misc julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:  | Pass  Error  Total
BigFloat Tests |    3      2      5
ERROR: Package BoundaryValueDiffEq errored during testing
```

## Passing after

```console
$ env JULIA_DEPOT_PATH=$DEPOT JULIA_PKG_PRECOMPILE_AUTO=0 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                           | Pass  Total   Time
DiffCache with SparseConnectivityTracer |   26     26  11.6s
Test Summary:  | Pass  Total     Time
Enzyme Support |   26     26  3m46.3s
Test Summary:               | Pass  Total  Time
Allocation Regression Tests |   27     27  3.3s
Testing PreallocationTools tests passed
```

The full Core group also passed Developer Interface (16/16), DiffCache Dispatch (82 pass, 10 existing broken), ODE (7/7), Resizing (64/64), Nested Duals (4/4), Sparsity Support (4/4), LazyBufferCache (2/2), GeneralLazyBufferCache (11/11), and Zero/Copy/Fill Dispatches (66/66).

The same full downstream group passes with the branch developed into BoundaryValueDiffEq:

```console
$ env JULIA_DEPOT_PATH=$DEPOT JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=Misc julia +1.12 --project=. -e 'using Pkg; Pkg.develop(path="../prealloc"); Pkg.test()'
Test Summary:    | Pass  Total      Time
Adaptivity Tests |   19     19  12m48.5s
Test Summary:          | Pass  Broken  Total     Time
Non-Vector Input Tests |   24       4     28  9m01.8s
Test Summary:  | Pass  Total     Time
BigFloat Tests |    7      7  6m09.7s
Test Summary: | Pass  Total     Time
Verbose Tests |   78     78  8m59.7s
Test Summary:   | Pass  Total     Time
Manifolds Tests |   11     11  4m22.8s
Testing BoundaryValueDiffEq tests passed
```

Initial Guess (6/6), Scalar BVP (4/4), Default Solvers (2/2), Public API Package Splits (12/12), and the zero-assertion Type Stability run also completed successfully.

## Other checks

```console
$ env JULIA_DEPOT_PATH=$DEPOT JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA            |   27     27  1m18.9s
Testing PreallocationTools tests passed

$ julia +1.12 --project=/home/crackauc/.julia/environments/runic -m Runic --check .
$ git diff | typos -
$ git diff --check
```

Runic, typos, and `git diff --check` exit successfully with no output.

Documentation was not built because this changes no public API, docstring, or documentation. GPU-specific paths were not run. The BoundaryValueDiffEq `Misc` group is the downstream integration coverage.

## CI context

- The reported NonlinearSolve PR job fails: https://github.com/SciML/NonlinearSolve.jl/actions/runs/31797173566/job/94756697971
- Clean NonlinearSolve master has the same failure: https://github.com/SciML/NonlinearSolve.jl/actions/runs/31767689368/job/94666822847
- BoundaryValueDiffEq's earlier green job used PreallocationTools v1.4.1: https://github.com/SciML/BoundaryValueDiffEq.jl/actions/runs/31497419809/job/93805990958
