### PR TITLE
Cache non-isbits ForwardDiff workspaces

### DIFF
--- a/ext/PreallocationToolsForwardDiffExt.jl
+++ b/ext/PreallocationToolsForwardDiffExt.jl
@@ -106,36 +106,36 @@ function diffcache_dual_tmp(dc::PreallocationTools.DiffCache, ::Type{T}) where {
             PreallocationTools._restructure(dc.du, view(reint, 1:length(dc.du)))
         end
     else
-        PreallocationTools._restructure(dc.du, zeros(cache_eltype, size(dc.du)))
+        PreallocationTools._typed_tmp(dc, cache_eltype)
+    end
+end
+
+function fixedsize_dual_tmp(
+        dc::PreallocationTools.FixedSizeDiffCache, ::Type{T}
+    ) where {T <: ForwardDiff.Dual}
+    if !isbitstype(T)
+        return PreallocationTools._typed_tmp(dc, dual_eltype(eltype(dc.du), T))
+    end
+
+    x = reinterpret(T, dc.dual_du)
+    return if PreallocationTools.chunksize(T) === PreallocationTools.chunksize(eltype(dc.dual_du))
+        x
+    else
+        @view x[axes(dc.du)...]
     end
 end
 
 # Define get_tmp methods for ForwardDiff.Dual types
 function PreallocationTools.get_tmp(dc::PreallocationTools.FixedSizeDiffCache, u::T) where {T <: ForwardDiff.Dual}
-    x = reinterpret(T, dc.dual_du)
-    return if PreallocationTools.chunksize(T) === PreallocationTools.chunksize(eltype(dc.dual_du))
-        x
-    else
-        @view x[axes(dc.du)...]
-    end
+    return fixedsize_dual_tmp(dc, T)
 end
 
 function PreallocationTools.get_tmp(dc::PreallocationTools.FixedSizeDiffCache, u::Type{T}) where {T <: ForwardDiff.Dual}
-    x = reinterpret(T, dc.dual_du)
-    return if PreallocationTools.chunksize(T) === PreallocationTools.chunksize(eltype(dc.dual_du))
-        x
-    else
-        @view x[axes(dc.du)...]
-    end
+    return fixedsize_dual_tmp(dc, T)
 end
 
 function PreallocationTools.get_tmp(dc::PreallocationTools.FixedSizeDiffCache, u::AbstractArray{T}) where {T <: ForwardDiff.Dual}
-    x = reinterpret(T, dc.dual_du)
-    return if PreallocationTools.chunksize(T) === PreallocationTools.chunksize(eltype(dc.dual_du))
-        x
-    else
-        @view x[axes(dc.du)...]
-    end
+    return fixedsize_dual_tmp(dc, T)
 end
 
 function PreallocationTools.get_tmp(dc::PreallocationTools.DiffCache, u::T) where {T <: ForwardDiff.Dual}

--- a/src/PreallocationTools.jl
+++ b/src/PreallocationTools.jl
@@ -343,6 +343,10 @@ Returns the `Dual` or normal cache array stored in `dc` based on the type of `u`
 
 # The compiler resolves this to a constant, and `:removable` lets it delete the
 # runtime allocation (same pattern as `_preserved_similar_type` for `LazyBufferCache`).
+Base.@assume_effects :removable function _typed_buffer_type(x::AbstractArray, ::Type{T}) where {T}
+    return typeof(similar(x, T, length(x)))
+end
+
 Base.@assume_effects :removable function _typed_tmp_type(x::AbstractArray, ::Type{T}) where {T}
     return typeof(_restructure(x, similar(x, T, length(x))))
 end
@@ -357,7 +361,7 @@ end
 function _typed_tmp(dc, ::Type{T}) where {T}
     buf = get!(dc.typed_du, T) do
         similar(dc.du, T, length(dc.du))
-    end
+    end::_typed_buffer_type(dc.du, T)
     if length(buf) != length(dc.du)
         # `du` was resized behind the cache's back (`Base.resize!` keeps the typed
         # workspaces in sync). Contents are scratch, so recreate.
@@ -495,6 +499,7 @@ PreallocationTools._restructure(cache::MyAD.Array, duals) = MyAD.Array(duals, ax
 ```
 """
 function _restructure(normal_cache::Array, duals)
+    size(normal_cache) == size(duals) && return duals
     return reshape(duals, size(normal_cache)...)
 end
 @public _restructure

--- a/test/core_dispatch.jl
+++ b/test/core_dispatch.jl
@@ -33,6 +33,15 @@ end
 
 Base.zero(::Type{IsbitsPair{T}}) where {T} = IsbitsPair(zero(T), zero(T))
 
+struct NonBitsReal <: Real
+    value::BigInt
+end
+
+NonBitsReal(x::Integer) = NonBitsReal(big(x))
+
+allocated_get_tmp(cache, input) = @allocated get_tmp(cache, input)
+allocated_get_tmp(cache, ::Type{T}) where {T} = @allocated get_tmp(cache, T)
+
 @testset "DiffCache accepts isbits elements without zero" begin
     u = [(; a = 1.0, b = (2.0, 3.0)), (; a = 4.0, b = (5.0, 6.0))]
     cache = DiffCache(u, 3)
@@ -47,6 +56,26 @@ Base.zero(::Type{IsbitsPair{T}}) where {T} = IsbitsPair(zero(T), zero(T))
 
     tmp[1] = (; a = zero(DualT), b = (zero(DualT), zero(DualT)))
     @test tmp[1] == (; a = zero(DualT), b = (zero(DualT), zero(DualT)))
+end
+
+@testset "non-isbits ForwardDiff workspaces" begin
+    DualT = ForwardDiff.Dual{Nothing, NonBitsReal, 2}
+    dual = DualT(
+        NonBitsReal(1),
+        ForwardDiff.Partials((NonBitsReal(1), NonBitsReal(0)))
+    )
+    duals = fill(dual, 3)
+
+    for cache in (DiffCache(zeros(3), 2), FixedSizeDiffCache(zeros(3), 2))
+        for input in (dual, DualT, duals)
+            workspace = get_tmp(cache, input)
+            workspace .= duals
+            @test eltype(workspace) === DualT
+            @test get_tmp(cache, input) == duals
+            allocated_get_tmp(cache, input)
+            @test allocated_get_tmp(cache, input) == 0
+        end
+    end
 end
 
 #Setup Base Array tests


### PR DESCRIPTION
## What changed and why

ForwardDiff Dual values whose scalar storage is not an isbits type could not use FixedSizeDiffCache and received a newly zeroed workspace on every DiffCache lookup. This caches correctly typed workspaces for both cache variants while retaining the existing reinterpret path for isbits Duals. Same-shaped array workspaces are returned directly so the warmed vector lookup used by Symbolics is allocation-free.

This makes the workaround discussed in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1968 unnecessary once Symbolics can require a PreallocationTools release containing this change.

## Verification

Failing before the implementation, with only the regression test applied:

    GROUP=Core julia --project -e "using Pkg; Pkg.test()"
    DiffCache Dispatch | 85 pass, 3 fail, 1 error, 10 broken, 99 total

The three failures showed that DiffCache returned fresh zeroed workspaces instead of retaining writes. FixedSizeDiffCache errored while trying to reinterpret a non-isbits Dual:

    ArgumentError: cannot reinterpret ForwardDiff.Dual{Nothing, Float64, 2} as ForwardDiff.Dual{Nothing, NonBitsReal, 2}, type ForwardDiff.Dual{Nothing, NonBitsReal, 2} is not a bits type

Passing after the implementation:

    GROUP=Core julia --project -e "using Pkg; Pkg.test()"
    DiffCache Dispatch | 100 pass, 10 broken, 110 total
    Allocation Regression Tests | 27 pass, 27 total
    Testing PreallocationTools tests passed

The new regression test covers Dual value, Dual type, and Dual array dispatch for DiffCache and FixedSizeDiffCache. Every warmed vector lookup reports 0 allocated bytes.

    GROUP=QA julia --project -e "using Pkg; Pkg.test()"
    QA | 27 pass, 27 total
    Testing PreallocationTools tests passed

    julia --project="$HOME/.julia/environments/runic" -m Runic --check --diff src/PreallocationTools.jl ext/PreallocationToolsForwardDiffExt.jl test/core_dispatch.jl
    exit 0

    typos src/PreallocationTools.jl ext/PreallocationToolsForwardDiffExt.jl test/core_dispatch.jl
    exit 0

    git diff --check
    exit 0

## Not verified

Docs were not built because this changes no public API, docstring, or documentation. GPU and downstream jobs were not run locally.

## Review note

The same-shape fast path in _restructure is what removes the final array-header allocation for vector typed buffers. Non-vector reshaping can still allocate only the reshape wrapper; the backing workspace remains cached. The existing isbits reinterpret behavior is unchanged.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47