### PR TITLE
Release PreallocationTools 1.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PreallocationTools"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "1.6.0"
+version = "1.7.0"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Releases the unreleased changes on `master` since 1.6.0:

- #209 — `Cache non-isbits ForwardDiff workspaces`. ForwardDiff `Dual` values whose scalar storage is not `isbits` previously received a newly zeroed workspace on every `DiffCache` lookup; both cache variants now cache correctly typed workspaces, and same-shaped array workspaces are returned directly so the warmed vector lookup is allocation-free.
- #208 — compat: drop stale majors.

**Minor**, matching this repo's convention (1.5.0 -> 1.6.0 carried the #206 batch). No exported or `public` name is added or removed, but downstreams need a floor to depend on the new allocation behaviour - JuliaSymbolics/Symbolics.jl#1968 is waiting on exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R