### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,7 +42,7 @@ ReverseDiff = "1.16"
 SafeTestsets = "0.1"
 SparseArrays = "1.10"
 SparseConnectivityTracer = "1"
-Symbolics = "7.6"
+Symbolics = "7.39.2"
 Test = "1.10"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
- Force Symbolics ≥7.39.2 so SymbolicUtils 4.46.4 resolves on x86.

## Test plan
- [ ] x86 green after Symbolics 7.39.2 registers

Made with [Cursor](https://cursor.com)