### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs,ForwardDiff"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,49 @@
+using PreallocationTools, BenchmarkTools
+using ForwardDiff, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+u0 = rand(rng, 500)
+duals = ForwardDiff.Dual.(u0, rand(rng, 500))
+
+# =============================================================================
+# LazyBufferCache / dualcache
+# =============================================================================
+
+SUITE["dualcache"] = BenchmarkGroup()
+
+SUITE["dualcache"]["construct"] = @benchmarkable dualcache($u0)
+dc = dualcache(u0)
+SUITE["dualcache"]["get_tmp_float"] = @benchmarkable get_tmp($dc, 1.0)
+SUITE["dualcache"]["get_tmp_dual"] = @benchmarkable get_tmp($dc, $(duals[1]))
+
+# =============================================================================
+# FixedSizeDiffCache
+# =============================================================================
+
+SUITE["fixed_size"] = BenchmarkGroup()
+
+fdc = FixedSizeDiffCache(u0)
+SUITE["fixed_size"]["construct"] = @benchmarkable FixedSizeDiffCache($u0)
+SUITE["fixed_size"]["get_tmp_float"] = @benchmarkable get_tmp($fdc, 1.0)
+SUITE["fixed_size"]["get_tmp_dual"] = @benchmarkable get_tmp($fdc, $(duals[1]))
+
+# =============================================================================
+# Realistic workload: in-place function over a DiffCache
+# =============================================================================
+
+SUITE["workload"] = BenchmarkGroup()
+
+function f_cache!(out, u, cache)
+    tmp = get_tmp(cache, u)
+    @. tmp = sin(u) * cos(u)
+    @. out = tmp + tmp^2
+    return nothing
+end
+
+out = similar(u0)
+SUITE["workload"]["float"] = @benchmarkable f_cache!($out, $u0, $dc)
+SUITE["workload"]["dual"] = @benchmarkable f_cache!(
+    od, ud, $dc
+) setup = (od = similar(u0, eltype(duals)); ud = duals)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~6s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~6s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md